### PR TITLE
Add Clash Royale deck generator

### DIFF
--- a/clash_deck_app.py
+++ b/clash_deck_app.py
@@ -1,0 +1,64 @@
+import streamlit as st
+import pandas as pd
+import random
+from pathlib import Path
+
+@st.cache_data(ttl=24*60*60)
+def load_card_data():
+    """Load Clash Royale card data. The data file can be updated over time."""
+    data_file = Path(__file__).parent / 'data' / 'clash_cards.csv'
+    return pd.read_csv(data_file)
+
+SYNERGY_PAIRS = {
+    ('Hog Rider', 'Fireball'): 1.0,
+    ('Balloon', 'Freeze'): 1.0,
+    ('Golem', 'Baby Dragon'): 1.0,
+    ('Royal Giant', 'Lightning'): 1.0,
+    ('Miner', 'Poison'): 1.0,
+    ('X-Bow', 'Tesla'): 1.0,
+    ('Rocket', 'X-Bow'): 1.0,
+    ('P.E.K.K.A', 'Bandit'): 1.0,
+    ('Mortar', 'Log'): 1.0,
+}
+
+def score_deck(deck_df: pd.DataFrame) -> float:
+    """Simple scoring for a deck."""
+    elixir_mean = deck_df['elixir'].mean()
+    score = -abs(elixir_mean - 3.5)
+    cards = set(deck_df['card'])
+    for pair, val in SYNERGY_PAIRS.items():
+        if set(pair).issubset(cards):
+            score += val
+    return score
+
+def generate_deck(cards_df: pd.DataFrame):
+    best_score = -999
+    best_deck = None
+    for _ in range(200):
+        building = cards_df[cards_df['type'] == 'building'].sample(1)
+        spell = cards_df[cards_df['type'] == 'spell'].sample(1)
+        remaining = cards_df[~cards_df['card'].isin(pd.concat([building, spell])['card'])].sample(6)
+        deck = pd.concat([building, spell, remaining])
+        deck_score = score_deck(deck)
+        if deck_score > best_score:
+            best_score = deck_score
+            best_deck = deck
+    return best_deck.reset_index(drop=True), best_score
+
+def main():
+    st.set_page_config(page_title='Clash Royale Deck Generator', page_icon='\u2694')
+    st.title('Clash Royale Deck Generator')
+    st.write('Este gerador usa uma IA simples para sugerir decks balanceados. O conjunto de cartas pode ser atualizado a qualquer momento para refletir as mudan\u00e7as do jogo.')
+    cards_df = load_card_data()
+    if st.button('Gerar novo deck'):
+        deck, score = generate_deck(cards_df)
+    else:
+        deck, score = generate_deck(cards_df)
+    avg_elixir = deck['elixir'].mean()
+    st.subheader(f'Custo m\u00e9dio de elixir: {avg_elixir:.2f}')
+    st.subheader(f'Pontua\u00e7\u00e3o do deck: {score:.2f}')
+    for idx, row in deck.iterrows():
+        st.write(f"{row['card']} ({row['elixir']} elixir)")
+
+if __name__ == '__main__':
+    main()

--- a/data/clash_cards.csv
+++ b/data/clash_cards.csv
@@ -1,0 +1,42 @@
+card,elixir,type
+Archers,3,troop
+Knight,3,troop
+Giant,5,troop
+Skeletons,1,troop
+Goblin Gang,3,troop
+Fireball,4,spell
+Zap,2,spell
+Cannon,3,building
+Musketeer,4,troop
+Valkyrie,4,troop
+Hog Rider,4,troop
+Wizard,5,troop
+P.E.K.K.A,7,troop
+X-Bow,6,building
+Rocket,6,spell
+Baby Dragon,4,troop
+Mega Minion,3,troop
+Balloon,5,troop
+Golem,8,troop
+Goblin Barrel,3,spell
+Tornado,3,spell
+Electro Wizard,4,troop
+Freeze,4,spell
+Mortar,4,building
+Bowler,5,troop
+Ice Spirit,1,troop
+Log,2,spell
+Skeleton Army,3,troop
+Royal Giant,6,troop
+Mini P.E.K.K.A,4,troop
+Minions,3,troop
+Rage,2,spell
+Sparky,6,troop
+Furnace,4,building
+Witch,5,troop
+Bandit,3,troop
+Poison,4,spell
+Miner,3,troop
+Heal Spirit,1,troop
+Lightning,6,spell
+Bomb Tower,4,building

--- a/data/clash_cards.csv
+++ b/data/clash_cards.csv
@@ -1,42 +1,121 @@
 card,elixir,type
-Archers,3,troop
 Knight,3,troop
+Archers,3,troop
+Goblins,2,troop
 Giant,5,troop
-Skeletons,1,troop
-Goblin Gang,3,troop
-Fireball,4,spell
-Zap,2,spell
-Cannon,3,building
-Musketeer,4,troop
-Valkyrie,4,troop
-Hog Rider,4,troop
-Wizard,5,troop
 P.E.K.K.A,7,troop
-X-Bow,6,building
-Rocket,6,spell
-Baby Dragon,4,troop
-Mega Minion,3,troop
-Balloon,5,troop
-Golem,8,troop
-Goblin Barrel,3,spell
-Tornado,3,spell
-Electro Wizard,4,troop
-Freeze,4,spell
-Mortar,4,building
-Bowler,5,troop
-Ice Spirit,1,troop
-Log,2,spell
-Skeleton Army,3,troop
-Royal Giant,6,troop
-Mini P.E.K.K.A,4,troop
 Minions,3,troop
-Rage,2,spell
-Sparky,6,troop
-Furnace,4,building
+Balloon,5,troop
 Witch,5,troop
-Bandit,3,troop
-Poison,4,spell
+Barbarians,5,troop
+Golem,8,troop
+Skeletons,1,troop
+Valkyrie,4,troop
+Skeleton Army,3,troop
+Bomber,2,troop
+Musketeer,4,troop
+Baby Dragon,4,troop
+Prince,5,troop
+Wizard,5,troop
+Mini P.E.K.K.A,4,troop
+Spear Goblins,2,troop
+Giant Skeleton,6,troop
+Hog Rider,4,troop
+Minion Horde,5,troop
+Ice Wizard,3,troop
+Royal Giant,6,troop
+Guards,3,troop
+Princess,3,troop
+Dark Prince,4,troop
+Three Musketeers,9,troop
+Lava Hound,7,troop
+Ice Spirit,1,troop
+Fire Spirit,1,troop
 Miner,3,troop
-Heal Spirit,1,troop
-Lightning,6,spell
+Sparky,6,troop
+Bowler,5,troop
+Lumberjack,4,troop
+Battle Ram,4,troop
+Inferno Dragon,4,troop
+Ice Golem,2,troop
+Mega Minion,3,troop
+Dart Goblin,3,troop
+Goblin Gang,3,troop
+Electro Wizard,4,troop
+Elite Barbarians,6,troop
+Hunter,4,troop
+Executioner,5,troop
+Bandit,3,troop
+Royal Recruits,7,troop
+Night Witch,4,troop
+Bats,2,troop
+Royal Ghost,3,troop
+Ram Rider,5,troop
+Zappies,4,troop
+Rascals,5,troop
+Cannon Cart,5,troop
+Mega Knight,7,troop
+Skeleton Barrel,3,troop
+Flying Machine,4,troop
+Wall Breakers,2,troop
+Royal Hogs,5,troop
+Goblin Giant,6,troop
+Fisherman,3,troop
+Magic Archer,4,troop
+Electro Dragon,5,troop
+Firecracker,3,troop
+Mighty Miner,4,troop
+Super Witch,6,troop
+Elixir Golem,3,troop
+Battle Healer,4,troop
+Skeleton King,4,troop
+Super Lava Hound,8,troop
+Super Magic Archer,5,troop
+Archer Queen,5,troop
+Santa Hog Rider,5,troop
+Golden Knight,4,troop
+Super Ice Golem,4,troop
+Monk,5,troop
+Super Archers,3,troop
+Skeleton Dragons,4,troop
+Terry,4,troop
+Super Mini P.E.K.K.A,5,troop
+Mother Witch,4,troop
+Electro Spirit,1,troop
+Electro Giant,7,troop
+Raging Prince,5,troop
+Phoenix,4,troop
+Cannon,3,building
+Goblin Hut,5,building
+Mortar,4,building
+Inferno Tower,5,building
 Bomb Tower,4,building
+Barbarian Hut,6,building
+Tesla,4,building
+Elixir Collector,6,building
+X-Bow,6,building
+Tombstone,3,building
+Furnace,4,building
+Goblin Cage,4,building
+Goblin Drill,4,building
+Party Hut,5,building
+Fireball,4,spell
+Arrows,3,spell
+Rage,2,spell
+Rocket,6,spell
+Goblin Barrel,3,spell
+Freeze,4,spell
+Mirror,1,spell
+Lightning,6,spell
+Zap,2,spell
+Poison,4,spell
+Graveyard,5,spell
+The Log,2,spell
+Tornado,3,spell
+Clone,3,spell
+Earthquake,3,spell
+Barbarian Barrel,2,spell
+Heal Spirit,1,troop
+Giant Snowball,2,spell
+Royal Delivery,3,spell
+Party Rocket,5,spell


### PR DESCRIPTION
## Summary
- add a dataset of Clash Royale cards
- create a Streamlit app that proposes decks using a simple AI heuristic

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile clash_deck_app.py`
- `python clash_deck_app.py` *(fails in headless mode as expected)*
- `python - <<'EOF'
from clash_deck_app import load_card_data, generate_deck
cards = load_card_data()
deck, score = generate_deck(cards)
print(deck)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688a659616388324a290d9cd98f9e478